### PR TITLE
BYOL hot fix with instance id variable

### DIFF
--- a/templates/sios-datakeeper.template.yaml
+++ b/templates/sios-datakeeper.template.yaml
@@ -1407,71 +1407,13 @@ Resources:
             - NextStep: CreateJob
               Variable: '{{AMIType}}'
               StringEquals: PAYG
-        - name: DownloadDKCELicenseNode1
+        - name: DownloadDKCELicenseNodes
           action: aws:runCommand
           onFailure: step:signalfailure
           inputs:
             DocumentName: AWS-RunRemoteScript
             InstanceIds:
-              - '{{wsfcnode1InstanceId.InstanceIds}}'
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: 'true'
-              CloudWatchLogGroupName: !Ref QuickStartLogs
-            Parameters:
-              sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DownloadDKCELicense.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: ./DownloadDKCELicense.ps1 -SIOSLicenseKeyFtpURL "{{SIOSLicenseKeyFtpURL}}"
-        - name: DownloadDKCELicenseNode2
-          action: aws:runCommand
-          onFailure: step:signalfailure
-          inputs:
-            DocumentName: AWS-RunRemoteScript
-            InstanceIds:
-              - '{{wsfcnode2InstanceId.InstanceIds}}'
-            CloudWatchOutputConfig:
-              CloudWatchOutputEnabled: 'true'
-              CloudWatchLogGroupName: !Ref QuickStartLogs
-            Parameters:
-              sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DownloadDKCELicense.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
-              commandLine: ./DownloadDKCELicense.ps1 -SIOSLicenseKeyFtpURL "{{SIOSLicenseKeyFtpURL}}"
-        - name: ThirdAZFullBranch1
-          action: aws:branch
-          inputs:
-            Choices:
-            - NextStep: CreateJob
-              Variable: '{{ThirdAZ}}'
-              StringEquals: none
-            - NextStep: CreateJob
-              Variable: '{{ThirdAZ}}'
-              StringEquals: witness
-        - name: DownloadDKCELicenseNode3
-          action: aws:runCommand
-          onFailure: step:signalfailure
-          inputs:
-            DocumentName: AWS-RunRemoteScript
-            InstanceIds:
-              - '{{wsfcnode3InstanceId.InstanceIds}}'
+              - '{{wsfcnodesInstanceId.InstanceIds}}'
             CloudWatchOutputConfig:
               CloudWatchOutputEnabled: 'true'
               CloudWatchLogGroupName: !Ref QuickStartLogs


### PR DESCRIPTION
During testing the team noticed that one of the instance ID variables was being misused. This caused the following AWS SSM Execution error: 

```
FailureMessage            : Step fails when it is validating and resolving the step inputs. Failed to resolve input:
                            wsfcnode1InstanceId.InstanceIds to type StringList or String. InstanceIds is not found in
                            the output of action aws:executeAwsApi.. Please refer to Automation Service
                            Troubleshooting Guide for more diagnosis details.
Targets                   : {}
ResolvedTargets           : @{ParameterValues=System.Object[]; Truncated=False}
AutomationType            : Local
```