### PR TITLE
S3Bucket Refactor

### DIFF
--- a/templates/sios-datakeeper.template.yaml
+++ b/templates/sios-datakeeper.template.yaml
@@ -2674,13 +2674,12 @@ Resources:
             - !If
               - UsingDefaultBucket
               - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Ref QSS3BucketName
+              - !Sub '${QSS3BucketName}'
             - ';"QSS3BucketRegion"='
             - !If
               - UsingDefaultBucket
-              - !Ref AWS::Region
-              - !Ref QSS3BucketRegion
-            - !Sub '"${QSS3BucketRegion}"'
+              - !Sub '${AWS::Region}'
+              - !Sub '${QSS3BucketRegion}'
             - ';"QSS3KeyPrefix"='
             - !Sub '"${QSS3KeyPrefix}"'
             - ';"StackName"='

--- a/templates/sios-datakeeper.template.yaml
+++ b/templates/sios-datakeeper.template.yaml
@@ -1135,9 +1135,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-dsc-modules.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-dsc-modules.ps1"}'
               commandLine: ./install-dsc-modules.ps1
         - name: LCMConfig
           action: aws:runCommand
@@ -1151,9 +1149,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
               commandLine: ./LCM-Config.ps1
         - name: EnableCredSSP
           action: aws:runCommand
@@ -1212,9 +1208,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}submodules/cfn-ps-microsoft-utilities/scripts/Set-Dns.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}submodules/cfn-ps-microsoft-utilities/scripts/Set-Dns.ps1"}'
               commandLine: ./Set-Dns.ps1 -ns1 {{ADServer1PrivateIP}} -ns2 {{ADServer2PrivateIP}}
         - name: CopyDriveLetterMapping
           action: aws:runCommand
@@ -1318,9 +1312,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DomainJoin.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DomainJoin.ps1"}'
               commandLine: ./DomainJoin.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -AdminSecret {{AdminSecrets}}
         - name: DomainJoinApply
           action: aws:runCommand
@@ -1356,9 +1348,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/OpenWSFCPorts.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/OpenWSFCPorts.ps1"}'
               commandLine: ./OpenWSFCPorts.ps1
         - name: ByolAmiBranch
           action: aws:branch
@@ -1379,9 +1369,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DownloadDKCELicense.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DownloadDKCELicense.ps1"}'
               commandLine: ./DownloadDKCELicense.ps1 -SIOSLicenseKeyFtpURL "{{SIOSLicenseKeyFtpURL}}"
         - name: CreateJob
           action: aws:runCommand
@@ -1395,9 +1383,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateJob.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateJob.ps1"}'
               commandLine: !If
                 - ThirdAzIsFullNode
                 - ./CreateJob.ps1 -JobName "vol.D" -JobDesc "DKCE Volume Protection" -SourceNames "{{WSFCNode1NetBIOSName}}.{{DomainDNSName}}","{{WSFCNode2NetBIOSName}}.{{DomainDNSName}}" -SourceVols "D","D" -SourceIPs "{{WSFCNode1PrivateIP1}}","{{WSFCNode2PrivateIP1}}" -TargetNames "{{WSFCNode2NetBIOSName}}.{{DomainDNSName}}","{{WSFCNode3NetBIOSName}}.{{DomainDNSName}}" -TargetIPs "{{WSFCNode2PrivateIP1}}","{{WSFCNode3PrivateIP1}}" -TargetVols "D","D" -SyncTypes "S","S","S"
@@ -1414,9 +1400,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateMirror.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateMirror.ps1"}'
               commandLine: !If
                 - ThirdAzIsFullNode
                 - ./CreateMirror.ps1 -SourceIP "{{WSFCNode1PrivateIP1}}" -Volume "D" -TargetIPs "{{WSFCNode2PrivateIP1}}","{{WSFCNode3PrivateIP1}}" -SyncTypes "S","S"
@@ -1469,9 +1453,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-fsw-modules.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-fsw-modules.ps1"}'
               commandLine: ./install-fsw-modules.ps1
         - name: WitnessCreateFileShare3AZ
           action: aws:runCommand
@@ -1485,9 +1467,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCFileShare.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCFileShare.ps1"}'
               commandLine: ./WSFCFileShare.ps1
         - name: InvokeADReplicationDC1
           action: aws:runCommand
@@ -1546,9 +1526,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
               commandLine: ./Node1Config.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -WSFCNode1PrivateIP2 {{WSFCNode1PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: ApplyWSFCNode1Config
           action: aws:runCommand
@@ -1593,9 +1571,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Set-Folder-Permissions.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Set-Folder-Permissions.ps1"}'
               commandLine:
                 !Sub
                   - ./Set-Folder-Permissions.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}} -ClusterName {{ClusterName}} ${ShareOption}
@@ -1616,9 +1592,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
               commandLine: ./Node1Config.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -WSFCNode1PrivateIP2 {{WSFCNode1PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: Node1Reboot1SQL
           action: aws:runCommand
@@ -1655,9 +1629,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode2PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: Node2Reboot1SQL
           action: aws:runCommand
@@ -1703,9 +1675,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode3PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: Node3Reboot1SQL
           action: aws:runCommand
@@ -1744,9 +1714,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
               commandLine: ./Node1Config.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -WSFCNode1PrivateIP2 {{WSFCNode1PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}}
         - name: ApplyWSFCNode1ConfigNoSQL
           action: aws:runCommand
@@ -1804,9 +1772,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode2PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}}
         - name: Node2Reboot1NoSQL
           action: aws:runCommand
@@ -1852,9 +1818,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode3PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}}
         - name: Node3Reboot1NoSQL
           action: aws:runCommand
@@ -1891,9 +1855,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCQuorumConfig.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCQuorumConfig.ps1"}'
               commandLine:
                 !Sub
                   - ./WSFCQuorumConfig.ps1 ${QuorumOption}
@@ -1922,9 +1884,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForCluster.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForCluster.ps1"}'
               commandLine: ./WaitForCluster.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -NetBIOSName {{WSFCNode1NetBIOSName}}
         - name: ConfigurePermissionsOnMAD
           action: aws:runCommand
@@ -1938,9 +1898,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Configure-MAD-Permissions.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Configure-MAD-Permissions.ps1"}'
               commandLine: ./Configure-MAD-Permissions.ps1 -AdminSecret {{AdminSecrets}} -DomainNetBIOSName '{{DomainNetBIOSName}}' -wsfcName '{{ClusterName}}'
         - name: registerclustervolume
           action: aws:runCommand
@@ -1954,9 +1912,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/RegisterClusterVolume.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/RegisterClusterVolume.ps1"}'
               commandLine: ./RegisterClusterVolume.ps1 -Volume D
         - name: InstallSQLBranch
           action: aws:branch
@@ -1978,9 +1934,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE.ps1"}'
               commandLine: ./InstallSQLEE.ps1 -SQLServerVersion 'SQL{{SQLServerVersion}}' -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}} -NetBIOSName {{WSFCNode1NetBIOSName}} -SQLServerClusterIP {{WSFCNode1PrivateIP3}} -ClusterSubnetCidr {{PrivateSubnet1CIDR}}
         - name: SQLInstallNode2MOF
           action: aws:runCommand
@@ -1994,9 +1948,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE-AddNode.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE-AddNode.ps1"}'
               commandLine: ./InstallSQLEE-AddNode.ps1 -SQLServerVersion 'SQL{{SQLServerVersion}}' -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}} -NetBIOSName {{WSFCNode2NetBIOSName}} -ClusterIPAddresses {{WSFCNode1PrivateIP3}},{{WSFCNode2PrivateIP3}} -ClusterSubnetCidrs {{PrivateSubnet1CIDR}},{{PrivateSubnet2CIDR}}
         - name: WaitForClusterGroup
           action: aws:runCommand
@@ -2010,9 +1962,7 @@ Resources:
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
               sourceType: S3
-              sourceInfo:
-                !Sub
-                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForClusterGroup.ps1"}'
+              sourceInfo: !Sub '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForClusterGroup.ps1"}'
               commandLine: ./WaitForClusterGroup.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -NetBIOSName {{WSFCNode2NetBIOSName}}
         # END INSTALL SQL branch3
         - name: DisableCredSSP

--- a/templates/sios-datakeeper.template.yaml
+++ b/templates/sios-datakeeper.template.yaml
@@ -2623,13 +2623,13 @@ Resources:
             - ';"QSS3BucketName"='
             - !If
               - UsingDefaultBucket
-              - !Sub '${QSS3BucketName}-${AWS::Region}'
-              - !Sub '${QSS3BucketName}'
+              - !Sub '"${QSS3BucketName}-${AWS::Region}"'
+              - !Sub '"${QSS3BucketName}"'
             - ';"QSS3BucketRegion"='
             - !If
               - UsingDefaultBucket
-              - !Sub '${AWS::Region}'
-              - !Sub '${QSS3BucketRegion}'
+              - !Sub '"${AWS::Region}"'
+              - !Sub '"${QSS3BucketRegion}"'
             - ';"QSS3KeyPrefix"='
             - !Sub '"${QSS3KeyPrefix}"'
             - ';"StackName"='

--- a/templates/sios-datakeeper.template.yaml
+++ b/templates/sios-datakeeper.template.yaml
@@ -1137,15 +1137,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-dsc-modules.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-dsc-modules.ps1"}'
               commandLine: ./install-dsc-modules.ps1
         - name: LCMConfig
           action: aws:runCommand
@@ -1161,15 +1153,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/LCM-Config.ps1"}'
               commandLine: ./LCM-Config.ps1
         - name: EnableCredSSP
           action: aws:runCommand
@@ -1230,15 +1214,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}submodules/cfn-ps-microsoft-utilities/scripts/Set-Dns.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}submodules/cfn-ps-microsoft-utilities/scripts/Set-Dns.ps1"}'
               commandLine: ./Set-Dns.ps1 -ns1 {{ADServer1PrivateIP}} -ns2 {{ADServer2PrivateIP}}
         - name: CopyDriveLetterMapping
           action: aws:runCommand
@@ -1344,15 +1320,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DomainJoin.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DomainJoin.ps1"}'
               commandLine: ./DomainJoin.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -AdminSecret {{AdminSecrets}}
         - name: DomainJoinApply
           action: aws:runCommand
@@ -1390,15 +1358,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/OpenWSFCPorts.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/OpenWSFCPorts.ps1"}'
               commandLine: ./OpenWSFCPorts.ps1
         - name: ByolAmiBranch
           action: aws:branch
@@ -1421,15 +1381,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DownloadDKCELicense.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/DownloadDKCELicense.ps1"}'
               commandLine: ./DownloadDKCELicense.ps1 -SIOSLicenseKeyFtpURL "{{SIOSLicenseKeyFtpURL}}"
         - name: CreateJob
           action: aws:runCommand
@@ -1445,15 +1397,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateJob.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateJob.ps1"}'
               commandLine: !If
                 - ThirdAzIsFullNode
                 - ./CreateJob.ps1 -JobName "vol.D" -JobDesc "DKCE Volume Protection" -SourceNames "{{WSFCNode1NetBIOSName}}.{{DomainDNSName}}","{{WSFCNode2NetBIOSName}}.{{DomainDNSName}}" -SourceVols "D","D" -SourceIPs "{{WSFCNode1PrivateIP1}}","{{WSFCNode2PrivateIP1}}" -TargetNames "{{WSFCNode2NetBIOSName}}.{{DomainDNSName}}","{{WSFCNode3NetBIOSName}}.{{DomainDNSName}}" -TargetIPs "{{WSFCNode2PrivateIP1}}","{{WSFCNode3PrivateIP1}}" -TargetVols "D","D" -SyncTypes "S","S","S"
@@ -1472,15 +1416,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateMirror.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/CreateMirror.ps1"}'
               commandLine: !If
                 - ThirdAzIsFullNode
                 - ./CreateMirror.ps1 -SourceIP "{{WSFCNode1PrivateIP1}}" -Volume "D" -TargetIPs "{{WSFCNode2PrivateIP1}}","{{WSFCNode3PrivateIP1}}" -SyncTypes "S","S"
@@ -1535,15 +1471,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-fsw-modules.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/install-fsw-modules.ps1"}'
               commandLine: ./install-fsw-modules.ps1
         - name: WitnessCreateFileShare3AZ
           action: aws:runCommand
@@ -1559,15 +1487,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCFileShare.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCFileShare.ps1"}'
               commandLine: ./WSFCFileShare.ps1
         - name: InvokeADReplicationDC1
           action: aws:runCommand
@@ -1628,15 +1548,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
               commandLine: ./Node1Config.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -WSFCNode1PrivateIP2 {{WSFCNode1PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: ApplyWSFCNode1Config
           action: aws:runCommand
@@ -1683,15 +1595,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Set-Folder-Permissions.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Set-Folder-Permissions.ps1"}'
               commandLine:
                 !Sub
                   - ./Set-Folder-Permissions.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}} -ClusterName {{ClusterName}} ${ShareOption}
@@ -1714,15 +1618,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
               commandLine: ./Node1Config.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -WSFCNode1PrivateIP2 {{WSFCNode1PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: Node1Reboot1SQL
           action: aws:runCommand
@@ -1761,15 +1657,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode2PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: Node2Reboot1SQL
           action: aws:runCommand
@@ -1817,15 +1705,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode3PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}}
         - name: Node3Reboot1SQL
           action: aws:runCommand
@@ -1866,15 +1746,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Node1Config.ps1"}'
               commandLine: ./Node1Config.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -DomainDNSName {{DomainDNSName}} -WSFCNode1PrivateIP2 {{WSFCNode1PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}}
         - name: ApplyWSFCNode1ConfigNoSQL
           action: aws:runCommand
@@ -1934,15 +1806,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode2PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}}
         - name: Node2Reboot1NoSQL
           action: aws:runCommand
@@ -1990,15 +1854,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/AdditionalNodeConfig.ps1"}'
               commandLine: ./AdditionalNodeConfig.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -WSFCNodePrivateIP2 {{WSFCNode3PrivateIP2}} -ClusterName {{ClusterName}} -AdminSecret {{AdminSecrets}}
         - name: Node3Reboot1NoSQL
           action: aws:runCommand
@@ -2037,15 +1893,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCQuorumConfig.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WSFCQuorumConfig.ps1"}'
               commandLine:
                 !Sub
                   - ./WSFCQuorumConfig.ps1 ${QuorumOption}
@@ -2076,15 +1924,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForCluster.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForCluster.ps1"}'
               commandLine: ./WaitForCluster.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -NetBIOSName {{WSFCNode1NetBIOSName}}
         - name: ConfigurePermissionsOnMAD
           action: aws:runCommand
@@ -2100,15 +1940,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Configure-MAD-Permissions.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/Configure-MAD-Permissions.ps1"}'
               commandLine: ./Configure-MAD-Permissions.ps1 -AdminSecret {{AdminSecrets}} -DomainNetBIOSName '{{DomainNetBIOSName}}' -wsfcName '{{ClusterName}}'
         - name: registerclustervolume
           action: aws:runCommand
@@ -2124,15 +1956,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/RegisterClusterVolume.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/RegisterClusterVolume.ps1"}'
               commandLine: ./RegisterClusterVolume.ps1 -Volume D
         - name: InstallSQLBranch
           action: aws:branch
@@ -2156,15 +1980,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE.ps1"}'
               commandLine: ./InstallSQLEE.ps1 -SQLServerVersion 'SQL{{SQLServerVersion}}' -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}} -NetBIOSName {{WSFCNode1NetBIOSName}} -SQLServerClusterIP {{WSFCNode1PrivateIP3}} -ClusterSubnetCidr {{PrivateSubnet1CIDR}}
         - name: SQLInstallNode2MOF
           action: aws:runCommand
@@ -2180,15 +1996,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE-AddNode.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/InstallSQLEE-AddNode.ps1"}'
               commandLine: ./InstallSQLEE-AddNode.ps1 -SQLServerVersion 'SQL{{SQLServerVersion}}' -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -SQLSecret {{SQLSecrets}} -NetBIOSName {{WSFCNode2NetBIOSName}} -ClusterIPAddresses {{WSFCNode1PrivateIP3}},{{WSFCNode2PrivateIP3}} -ClusterSubnetCidrs {{PrivateSubnet1CIDR}},{{PrivateSubnet2CIDR}}
         - name: WaitForClusterGroup
           action: aws:runCommand
@@ -2204,15 +2012,7 @@ Resources:
               sourceType: S3
               sourceInfo:
                 !Sub
-                  - '{"path": "https://${S3Bucket}.s3.${S3Region}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForClusterGroup.ps1"}'
-                  - S3Bucket: !If
-                      - UsingDefaultBucket
-                      - !Sub '${QSS3BucketName}-${AWS::Region}'
-                      - !Ref QSS3BucketName
-                    S3Region: !If
-                      - UsingDefaultBucket
-                      - !Ref AWS::Region
-                      - !Ref QSS3BucketRegion
+                  - '{"path": "https://{{QSS3BucketName}}.s3.{{QSS3BucketRegion}}.{{URLSuffix}}/{{QSS3KeyPrefix}}scripts/WaitForClusterGroup.ps1"}'
               commandLine: ./WaitForClusterGroup.ps1 -DomainNetBIOSName {{DomainNetBIOSName}} -AdminSecret {{AdminSecrets}} -NetBIOSName {{WSFCNode2NetBIOSName}}
         # END INSTALL SQL branch3
         - name: DisableCredSSP
@@ -2871,8 +2671,15 @@ Resources:
                   - !Sub ${WSFCWitnessNetBIOSName}
                   - !Sub ${WSFCNode3NetBIOSName}
             - ';"QSS3BucketName"='
-            - !Sub '"${QSS3BucketName}"'
+            - !If
+              - UsingDefaultBucket
+              - !Sub '${QSS3BucketName}-${AWS::Region}'
+              - !Ref QSS3BucketName
             - ';"QSS3BucketRegion"='
+            - !If
+              - UsingDefaultBucket
+              - !Ref AWS::Region
+              - !Ref QSS3BucketRegion
             - !Sub '"${QSS3BucketRegion}"'
             - ';"QSS3KeyPrefix"='
             - !Sub '"${QSS3KeyPrefix}"'


### PR DESCRIPTION
allows the AWS default branch name to be `aws-ia` and dynamically checks whether or not to append the `{{AWS::Region}}` value if the bucketname is `aws-ia`

1. Before Launching the `SSM Document`, set the s3 bucket container to the correct name. 
2. Remove the multiple places of conditional checking for one single place of checking. (before launching powershell scripts).